### PR TITLE
Fix Errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { css } from 'emotion'
-import DateTime from 'react-datetime'
+import DateTime, { moment } from 'react-datetime'
 import Button from './components/Button'
 import 'react-datetime/css/react-datetime.css'
 import { appStyles, headerStyles, formStyles } from './App.styles'
@@ -8,7 +8,7 @@ import { CLIENT_RENEG_LIMIT } from 'tls'
 class App extends Component {
   state = {
     link: '',
-    date: new Date(),
+    date: moment(),
     day: '',
     time: '',
     timezone: ''
@@ -19,6 +19,10 @@ class App extends Component {
     this.setState({
       timezone
     })
+  }
+
+  componentDidMount() {
+    this.setDateAndTime(this.state.date)
   }
 
   generateLink = () => {
@@ -41,8 +45,10 @@ class App extends Component {
   }
 
   handleChange = date => {
+    console.log(date)
     this.setState({
-      date
+      date,
+      link: ''
     })
   }
 
@@ -51,6 +57,7 @@ class App extends Component {
       day: date.format('YYYY-MM-DD'),
       time: date.format('h:mm a')
     })
+    //check if date has been changed...
   }
 
   render() {
@@ -73,7 +80,7 @@ class App extends Component {
               />
             </div>
           </form>
-          <Button text="Generate Link" onClick={this.generateLink}/>
+          <Button text="Generate Link" onClick={this.generateLink} />
         </main>
         {link !== '' && (
           <footer>


### PR DESCRIPTION
Before, when you first loaded the extension and clicked generate link, it would work but the date and time were missing. Now, the date prop in state is a moment object and set when the component mounts. This way, you can click the link as soon as the app loads. I also made it so if you change the date or time, the link is removed. This is not optimal but solves the problem now.